### PR TITLE
Integrate ESG-aware offer evaluation and company selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,17 +3,24 @@ import Header from './components/Header/Header'
 import IntentForm from './components/IntentForm/IntentForm'
 import KanbanBoard from './components/KanbanBoard/KanbanBoard'
 import NegotiationDrawer from './components/NegotiationDrawer/NegotiationDrawer'
-import { sampleData } from './data/sampleData'
+import { sampleData, availableCompanies } from './data/sampleData'
 import { rolePermissions } from './utils/rolePermissions'
 import { v4 as uuidv4 } from 'uuid'
+import { evaluateAllOffersLLM } from './services/llmService'
+import { bankConfigs } from './data/bankConfigs'
+import { companyConfigs, generateCompanyConfig } from './data/companyConfigs'
+import { getChatSession, generateDealId } from './utils/chatStorage'
 
 function App() {
   const [currentRole, setCurrentRole] = useState('company')
   const [selectedBank, setSelectedBank] = useState('')
+  const [selectedCompany, setSelectedCompany] = useState(availableCompanies[0]?.name || '')
   const [intents, setIntents] = useState(sampleData.intents)
   const [ongoingDeals, setOngoingDeals] = useState(sampleData.ongoingDeals)
   const [closedDeals, setClosedDeals] = useState(sampleData.closedDeals)
   const [nextIntentId, setNextIntentId] = useState(1004)
+  const [intentEvaluations, setIntentEvaluations] = useState({})
+  const [evaluationLoading, setEvaluationLoading] = useState({})
 
   // Negotiation drawer state
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -25,12 +32,19 @@ function App() {
   const handleRoleChange = (role) => {
     setCurrentRole(role)
     setSelectedBank('')
+    if (role === 'company' && !selectedCompany) {
+      setSelectedCompany(availableCompanies[0]?.name || '')
+    }
     // Close drawer when role changes
     setIsDrawerOpen(false)
   }
 
   const handleBankSelection = (bank) => {
     setSelectedBank(bank)
+  }
+
+  const handleCompanySelection = (company) => {
+    setSelectedCompany(company)
   }
 
   const handleCreateIntent = (intentData) => {
@@ -83,12 +97,24 @@ function App() {
 
     // Remove intent from open intents
     setIntents(prev => prev.filter(i => i.id !== intentId))
-    
+
     // Remove all ongoing deals for this intent
     setOngoingDeals(prev => prev.filter(deal => deal.intentId !== intentId))
-    
+
     // Add to closed deals
     setClosedDeals(prev => [...prev, closedDeal])
+
+    setIntentEvaluations(prev => {
+      const next = { ...prev }
+      delete next[intentId]
+      return next
+    })
+
+    setEvaluationLoading(prev => {
+      const next = { ...prev }
+      delete next[intentId]
+      return next
+    })
   }
 
   const handleDeleteIntent = (intentId) => {
@@ -96,6 +122,95 @@ function App() {
 
     setIntents(prev => prev.filter(i => i.id !== intentId))
     setOngoingDeals(prev => prev.filter(deal => deal.intentId !== intentId))
+
+    setIntentEvaluations(prev => {
+      const next = { ...prev }
+      delete next[intentId]
+      return next
+    })
+
+    setEvaluationLoading(prev => {
+      const next = { ...prev }
+      delete next[intentId]
+      return next
+    })
+  }
+
+  const handleEvaluateAllOffers = async (intentId) => {
+    const intent = intents.find(i => i.id === intentId)
+    if (!intent) return
+
+    const relatedDeals = ongoingDeals.filter(deal => deal.intentId === intentId)
+
+    if (relatedDeals.length === 0) {
+      setIntentEvaluations(prev => ({
+        ...prev,
+        [intentId]: {
+          content: 'No bank offers are available for this intent yet. Invite banks to submit proposals first.',
+          decision: 'NO_OFFERS',
+          recommendedPartner: null,
+          generatedAt: new Date().toISOString()
+        }
+      }))
+      return
+    }
+
+    setEvaluationLoading(prev => ({ ...prev, [intentId]: true }))
+
+    try {
+      const offerBundles = relatedDeals.map(deal => {
+        const sessionId = generateDealId(deal.intentId, deal.bankName)
+        let session = { messages: [], status: 'pending_verification' }
+
+        if (typeof window !== 'undefined') {
+          session = getChatSession(sessionId)
+        }
+
+        const bankMessages = (session.messages || []).filter(msg => msg.sender === deal.bankName)
+        const latestBankMessage = bankMessages[bankMessages.length - 1]
+        const conversationExcerpt = (session.messages || [])
+          .map(msg => `${msg.sender}: ${msg.content}`)
+          .slice(-6)
+          .join('\n')
+
+        return {
+          bankName: deal.bankName,
+          latestOffer: latestBankMessage?.content || 'No formalised offer from this bank yet.',
+          negotiationStatus: session.status || 'pending_verification',
+          conversationExcerpt,
+          bankConfig: bankConfigs[deal.bankName] || {}
+        }
+      })
+
+      const companyConfig = companyConfigs[intent.companyName] ||
+        generateCompanyConfig(intent.companyName, intent)
+
+      const evaluation = await evaluateAllOffersLLM(intent, offerBundles, companyConfig)
+
+      setIntentEvaluations(prev => ({
+        ...prev,
+        [intentId]: {
+          ...evaluation,
+          generatedAt: new Date().toISOString()
+        }
+      }))
+    } catch (error) {
+      setIntentEvaluations(prev => ({
+        ...prev,
+        [intentId]: {
+          content: `Error evaluating offers: ${error.message}`,
+          decision: 'ERROR',
+          recommendedPartner: null,
+          generatedAt: new Date().toISOString()
+        }
+      }))
+    } finally {
+      setEvaluationLoading(prev => {
+        const next = { ...prev }
+        delete next[intentId]
+        return next
+      })
+    }
   }
 
   // Negotiation drawer handlers
@@ -143,6 +258,12 @@ function App() {
   const handleDealCancelled = (intentId) => {
     // Remove all ongoing deals for this intent
     setOngoingDeals(prev => prev.filter(deal => deal.intentId !== intentId))
+
+    setIntentEvaluations(prev => {
+      const next = { ...prev }
+      delete next[intentId]
+      return next
+    })
   }
 
   return (
@@ -150,18 +271,21 @@ function App() {
       <Header
         currentRole={currentRole}
         selectedBank={selectedBank}
+        selectedCompany={selectedCompany}
         onRoleChange={handleRoleChange}
         onBankSelection={handleBankSelection}
+        onCompanySelection={handleCompanySelection}
         permissions={permissions}
       />
-      
+
       {permissions.canCreateIntents && (
         <IntentForm
           onCreateIntent={handleCreateIntent}
           currentRole={currentRole}
+          selectedCompany={selectedCompany}
         />
       )}
-      
+
       <KanbanBoard
         intents={intents}
         ongoingDeals={ongoingDeals}
@@ -173,6 +297,9 @@ function App() {
         onCloseDeal={handleCloseDeal}
         onDeleteIntent={handleDeleteIntent}
         onOpenNegotiation={handleOpenNegotiation}
+        onEvaluateAllOffers={handleEvaluateAllOffers}
+        evaluationSummaries={intentEvaluations}
+        evaluationLoading={evaluationLoading}
       />
 
       {/* Negotiation Drawer */}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,12 +1,14 @@
-import { roles, availableBanks } from '../../data/sampleData'
+import { roles, availableBanks, availableCompanies } from '../../data/sampleData'
 import { getRoleDisplayName } from '../../utils/rolePermissions'
 
-const Header = ({ 
-  currentRole, 
-  selectedBank, 
-  onRoleChange, 
+const Header = ({
+  currentRole,
+  selectedBank,
+  selectedCompany,
+  onRoleChange,
   onBankSelection,
-  permissions 
+  onCompanySelection,
+  permissions
 }) => {
   const getRoleBadgeClass = (role) => {
     const baseClass = "inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-semibold capitalize"
@@ -87,6 +89,33 @@ const Header = ({
                     </option>
                   ))}
                 </select>
+              </div>
+            )}
+
+            {/* Company Selector for Company Role */}
+            {currentRole === 'company' && (
+              <div className="flex flex-col gap-2">
+                <label htmlFor="companySelect" className="text-sm font-semibold text-gray-700">
+                  Select Company:
+                </label>
+                <select
+                  id="companySelect"
+                  className="form-input min-w-56"
+                  value={selectedCompany}
+                  onChange={(e) => onCompanySelection(e.target.value)}
+                >
+                  <option value="">Choose a company...</option>
+                  {availableCompanies.map(company => (
+                    <option key={company.id} value={company.name}>
+                      {company.name}
+                    </option>
+                  ))}
+                </select>
+                {selectedCompany && (
+                  <p className="text-xs text-gray-500 max-w-xs">
+                    {availableCompanies.find(company => company.name === selectedCompany)?.description}
+                  </p>
+                )}
               </div>
             )}
 

--- a/src/components/IntentCard/IntentCard.jsx
+++ b/src/components/IntentCard/IntentCard.jsx
@@ -1,14 +1,18 @@
 import { format } from 'date-fns'
 import { availableBanks } from '../../data/sampleData'
 
-const IntentCard = ({ 
-  intent, 
-  currentRole, 
+const IntentCard = ({
+  intent,
+  currentRole,
   selectedBank,
-  permissions, 
-  onExpressInterest, 
+  permissions,
+  onExpressInterest,
   onDeleteIntent,
-  hasOngoingDeals 
+  hasOngoingDeals,
+  deals = [],
+  onEvaluateAllOffers,
+  evaluationSummary,
+  isEvaluating
 }) => {
   const formatAmount = (amount) => {
     return new Intl.NumberFormat('en-US', {
@@ -42,6 +46,37 @@ const IntentCard = ({
     if (permissions.canDelete) {
       onDeleteIntent(intent.id)
     }
+  }
+
+  const handleEvaluateAllOffers = () => {
+    if (onEvaluateAllOffers) {
+      onEvaluateAllOffers(intent.id)
+    }
+  }
+
+  const dealsCount = deals?.length || 0
+  const canRunCompanyEvaluation = currentRole === 'company' && permissions.canViewOpenIntents
+  const hasOfferData = dealsCount > 0
+
+  const renderDecisionBadge = (decision) => {
+    if (!decision) return null
+
+    const normalized = decision.toUpperCase()
+    let badgeClass = 'bg-gray-100 text-gray-700'
+
+    if (normalized.includes('SELECT') || normalized.includes('ACCEPT')) {
+      badgeClass = 'bg-success-100 text-success-800'
+    } else if (normalized.includes('REQUEST') || normalized.includes('COUNTER')) {
+      badgeClass = 'bg-warning-100 text-warning-800'
+    } else if (normalized.includes('DECLINE') || normalized.includes('NO_OFFERS') || normalized.includes('ERROR')) {
+      badgeClass = 'bg-danger-100 text-danger-700'
+    }
+
+    return (
+      <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${badgeClass}`}>
+        {normalized.replace(/_/g, ' ')}
+      </span>
+    )
   }
 
   return (
@@ -109,8 +144,30 @@ const IntentCard = ({
             Has Active Negotiations
           </div>
         )}
+
+        {currentRole === 'company' && evaluationSummary && (
+          <div className="mt-3 bg-primary-50 border border-primary-200 text-primary-900 rounded-lg p-3 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide">AI ESG Review</span>
+              {renderDecisionBadge(evaluationSummary.decision)}
+            </div>
+            {evaluationSummary.recommendedPartner && (
+              <p className="text-sm font-semibold">
+                Recommended Partner: <span className="text-primary-700">{evaluationSummary.recommendedPartner}</span>
+              </p>
+            )}
+            <p className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
+              {evaluationSummary.content}
+            </p>
+            {evaluationSummary.generatedAt && (
+              <p className="text-[10px] text-primary-700 uppercase tracking-wide">
+                Generated {new Date(evaluationSummary.generatedAt).toLocaleString()}
+              </p>
+            )}
+          </div>
+        )}
       </div>
-      
+
       {/* Card Actions */}
       {canExpressInterest() && !permissions.isReadOnly && (
         <div className="p-4 pt-3 border-t border-gray-100 bg-gray-50">
@@ -128,6 +185,30 @@ const IntentCard = ({
           <div className="text-center text-xs text-gray-500 italic py-2">
             Select a bank to express interest
           </div>
+        </div>
+      )}
+
+      {canRunCompanyEvaluation && (
+        <div className="p-4 pt-3 border-t border-gray-100 bg-gray-50 space-y-3">
+          <button
+            className={`w-full btn btn-primary ${hasOfferData ? 'hover:scale-105' : 'opacity-70 cursor-not-allowed'} ${isEvaluating ? 'opacity-60 cursor-wait' : ''}`}
+            onClick={handleEvaluateAllOffers}
+            disabled={!hasOfferData || isEvaluating}
+          >
+            {isEvaluating ? (
+              <div className="flex items-center justify-center gap-2">
+                <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
+                Evaluating offers...
+              </div>
+            ) : (
+              'Run ESG Offer Review'
+            )}
+          </button>
+          {!hasOfferData && (
+            <p className="text-xs text-gray-500 text-center">
+              Waiting for banks to submit offers before running the ESG review.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/src/components/IntentForm/IntentForm.jsx
+++ b/src/components/IntentForm/IntentForm.jsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
-const IntentForm = ({ onCreateIntent, currentRole }) => {
+const IntentForm = ({ onCreateIntent, currentRole, selectedCompany }) => {
   const [formData, setFormData] = useState({
     companyName: '',
     amount: '',
@@ -10,14 +10,36 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errors, setErrors] = useState({})
 
+  const isCompanyRole = currentRole === 'company'
+
+  useEffect(() => {
+    if (isCompanyRole) {
+      setFormData(prev => ({
+        ...prev,
+        companyName: selectedCompany || ''
+      }))
+
+      if (selectedCompany) {
+        setErrors(prev => ({
+          ...prev,
+          companyName: ''
+        }))
+      }
+    }
+  }, [selectedCompany, isCompanyRole])
+
   const handleChange = (e) => {
     const { name, value } = e.target
+
+    if (name === 'companyName' && isCompanyRole) {
+      return
+    }
+
     setFormData(prev => ({
       ...prev,
       [name]: value
     }))
-    
-    // Clear error for this field when user starts typing
+
     if (errors[name]) {
       setErrors(prev => ({
         ...prev,
@@ -28,52 +50,54 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
 
   const validateForm = () => {
     const newErrors = {}
-    
+
     if (!formData.companyName.trim()) {
       newErrors.companyName = 'Company name is required'
     }
-    
+
+    if (isCompanyRole && !selectedCompany) {
+      newErrors.companyName = 'Select a company before creating an intent'
+    }
+
     if (!formData.amount || formData.amount <= 0) {
       newErrors.amount = 'Valid amount is required'
     }
-    
+
     if (!formData.duration || formData.duration <= 0) {
       newErrors.duration = 'Valid duration is required'
     }
-    
+
     if (!formData.purpose.trim()) {
       newErrors.purpose = 'Purpose is required'
     }
-    
+
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    
+
     if (!validateForm()) {
       return
     }
-    
+
     setIsSubmitting(true)
-    
+
     try {
       await onCreateIntent({
         companyName: formData.companyName.trim(),
-        amount: parseInt(formData.amount),
-        duration: parseInt(formData.duration),
+        amount: parseInt(formData.amount, 10),
+        duration: parseInt(formData.duration, 10),
         purpose: formData.purpose.trim()
       })
-      
-      // Reset form after successful submission
+
       setFormData({
-        companyName: '',
+        companyName: isCompanyRole ? (selectedCompany || '') : '',
         amount: '',
         duration: '',
         purpose: ''
       })
-      
     } catch (error) {
       console.error('Error creating intent:', error)
     } finally {
@@ -85,7 +109,6 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
     <section className="py-6 bg-gray-50">
       <div className="max-w-7xl mx-auto px-6">
         <div className="card max-w-4xl mx-auto overflow-hidden animate-fade-in">
-          {/* Card Header */}
           <div className="px-6 py-5 border-b border-gray-200 bg-gradient-to-r from-primary-50 to-primary-100">
             <h2 className="text-xl font-bold text-gray-900 mb-1">
               Create New Credit Intent
@@ -94,11 +117,9 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
               Submit a new credit line request to the marketplace
             </p>
           </div>
-          
-          {/* Form */}
+
           <form className="p-6" onSubmit={handleSubmit}>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-              {/* Company Name */}
               <div className="space-y-1">
                 <label htmlFor="companyName" className="form-label">
                   Company Name *
@@ -107,11 +128,12 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
                   type="text"
                   id="companyName"
                   name="companyName"
-                  className={`form-input ${errors.companyName ? 'border-danger-300 focus:ring-danger-500 focus:border-danger-500' : ''}`}
+                  className={`form-input ${errors.companyName ? 'border-danger-300 focus:ring-danger-500 focus:border-danger-500' : ''} ${isCompanyRole ? 'bg-gray-100 cursor-not-allowed' : ''}`}
                   value={formData.companyName}
                   onChange={handleChange}
-                  placeholder="Enter company name"
+                  placeholder={isCompanyRole ? 'Select a company from the header' : 'Enter company name'}
                   required
+                  readOnly={isCompanyRole}
                 />
                 {errors.companyName && (
                   <p className="text-danger-600 text-sm font-medium flex items-center gap-1">
@@ -119,9 +141,14 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
                     {errors.companyName}
                   </p>
                 )}
+                {isCompanyRole && !selectedCompany && (
+                  <p className="text-xs text-gray-500 flex items-center gap-1">
+                    <span>ℹ️</span>
+                    Choose a company above to auto-fill this field.
+                  </p>
+                )}
               </div>
-              
-              {/* Amount */}
+
               <div className="space-y-1">
                 <label htmlFor="amount" className="form-label">
                   Amount ($) *
@@ -150,8 +177,7 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
                   </p>
                 )}
               </div>
-              
-              {/* Duration */}
+
               <div className="space-y-1">
                 <label htmlFor="duration" className="form-label">
                   Duration (months) *
@@ -175,8 +201,7 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
                   </p>
                 )}
               </div>
-              
-              {/* Purpose */}
+
               <div className="md:col-span-2 space-y-1">
                 <label htmlFor="purpose" className="form-label">
                   Purpose *
@@ -199,13 +224,12 @@ const IntentForm = ({ onCreateIntent, currentRole }) => {
                 )}
               </div>
             </div>
-            
-            {/* Form Actions */}
+
             <div className="flex justify-end pt-4 border-t border-gray-200">
               <button
                 type="submit"
                 className={`btn btn-primary min-w-40 ${isSubmitting ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-md hover:scale-105'}`}
-                disabled={isSubmitting}
+                disabled={isSubmitting || (isCompanyRole && !selectedCompany)}
               >
                 {isSubmitting ? (
                   <div className="flex items-center gap-2">

--- a/src/components/KanbanBoard/KanbanBoard.jsx
+++ b/src/components/KanbanBoard/KanbanBoard.jsx
@@ -13,7 +13,10 @@ const KanbanBoard = ({
   onExpressInterest,
   onCloseDeal,
   onDeleteIntent,
-  onOpenNegotiation
+  onOpenNegotiation,
+  onEvaluateAllOffers,
+  evaluationSummaries,
+  evaluationLoading
 }) => {
   // Filter ongoing deals based on role permissions
   const visibleOngoingDeals = ongoingDeals.filter(deal => 
@@ -90,6 +93,10 @@ const KanbanBoard = ({
                       onExpressInterest={onExpressInterest}
                       onDeleteIntent={onDeleteIntent}
                       hasOngoingDeals={ongoingDealsByIntent[intent.id]?.length > 0}
+                      deals={ongoingDealsByIntent[intent.id] || []}
+                      onEvaluateAllOffers={onEvaluateAllOffers}
+                      evaluationSummary={evaluationSummaries?.[intent.id]}
+                      isEvaluating={!!evaluationLoading?.[intent.id]}
                     />
                   ))}
                 </div>

--- a/src/components/NegotiationDrawer/NegotiationDrawer.jsx
+++ b/src/components/NegotiationDrawer/NegotiationDrawer.jsx
@@ -162,9 +162,11 @@ const NegotiationDrawer = ({
       
       const conversation = chatSession.messages.filter(msg => msg.type !== 'system')
       const evaluation = await evaluateOfferLLM(
-        intent, 
-        lastBankMessage.content, 
-        companyConfig, 
+        intent,
+        lastBankMessage.content,
+        companyConfig,
+        bankConfig,
+        deal.bankName,
         conversation
       )
       

--- a/src/data/bankConfigs.js
+++ b/src/data/bankConfigs.js
@@ -11,7 +11,22 @@ export const bankConfigs = {
     negotiationStyle: "conservative",
     specializations: ["technology", "healthcare"],
     decisionSpeed: "fast",
-    flexibility: "medium"
+    flexibility: "medium",
+    esgFocusAreas: [
+      "clean technology scale-ups",
+      "resource-efficient manufacturing"
+    ],
+    esgExclusionList: [
+      "coal expansion",
+      "unsustainable palm oil",
+      "weapons manufacturing"
+    ],
+    esgMinimumScore: 72,
+    esgIncentives: "0.20% rate reduction for SBTi-validated plans and additional principal grace for emissions-linked KPIs",
+    esgReportingExpectations: "Quarterly sustainability reports referencing TCFD and GRI metrics with audited carbon accounting",
+    esgScoringWeights: { environmental: 0.45, social: 0.35, governance: 0.2 },
+    impactPreference: "Looks for measurable Scope 1 and 2 carbon reductions and workforce transition plans",
+    transitionFinancePolicy: "Supports borrowers with interim science-based targets for 2030 and board oversight on sustainability"
   },
   "Beta Financial": {
     riskTolerance: "high",
@@ -25,7 +40,21 @@ export const bankConfigs = {
     negotiationStyle: "aggressive",
     specializations: ["renewable energy", "manufacturing"],
     decisionSpeed: "medium",
-    flexibility: "high"
+    flexibility: "high",
+    esgFocusAreas: [
+      "renewable energy infrastructure",
+      "circular economy manufacturing"
+    ],
+    esgExclusionList: [
+      "thermal coal",
+      "single-use plastics expansion"
+    ],
+    esgMinimumScore: 68,
+    esgIncentives: "0.35% rate reduction for verified carbon-neutral operations with step-down incentives when impact KPIs are met",
+    esgReportingExpectations: "Semi-annual sustainability dashboards referencing SASB and EU taxonomy metrics",
+    esgScoringWeights: { environmental: 0.5, social: 0.3, governance: 0.2 },
+    impactPreference: "Prioritizes projects delivering grid decarbonization or green job creation",
+    transitionFinancePolicy: "Finances transition plans with transparent capex allocation to decarbonisation levers"
   },
   "Gamma Capital": {
     riskTolerance: "low",
@@ -39,7 +68,22 @@ export const bankConfigs = {
     negotiationStyle: "cautious",
     specializations: ["retail", "services"],
     decisionSpeed: "slow",
-    flexibility: "low"
+    flexibility: "low",
+    esgFocusAreas: [
+      "community health outcomes",
+      "responsible retail supply chains"
+    ],
+    esgExclusionList: [
+      "gambling expansion",
+      "tobacco manufacturing",
+      "labor-rights controversies"
+    ],
+    esgMinimumScore: 75,
+    esgIncentives: "0.15% rate reduction when social impact KPIs are verified and payment holidays for inclusive hiring goals",
+    esgReportingExpectations: "Annual impact reporting aligned to B Corp standards and independent social audits",
+    esgScoringWeights: { environmental: 0.3, social: 0.45, governance: 0.25 },
+    impactPreference: "Emphasizes supplier diversity programmes and patient access metrics",
+    transitionFinancePolicy: "Prefers borrowers with board-level ESG committees overseeing ethics compliance"
   },
   "Delta Bank": {
     riskTolerance: "medium-high",
@@ -53,7 +97,22 @@ export const bankConfigs = {
     negotiationStyle: "balanced",
     specializations: ["technology", "manufacturing", "healthcare"],
     decisionSpeed: "fast",
-    flexibility: "high"
+    flexibility: "high",
+    esgFocusAreas: [
+      "smart manufacturing efficiency",
+      "low-carbon logistics",
+      "healthcare innovation"
+    ],
+    esgExclusionList: [
+      "coal-fired power procurement",
+      "deforestation-linked sourcing"
+    ],
+    esgMinimumScore: 70,
+    esgIncentives: "0.25% blended-rate reduction for digital energy monitoring and green fleet conversion milestones",
+    esgReportingExpectations: "Quarterly KPI tracking via shared sustainability dashboards aligned with ISO 14001",
+    esgScoringWeights: { environmental: 0.4, social: 0.3, governance: 0.3 },
+    impactPreference: "Targets measurable energy intensity reductions and workforce safety improvements",
+    transitionFinancePolicy: "Requires transition plans with 2028 interim emissions targets and supplier engagement strategy"
   },
   "Epsilon Trust": {
     riskTolerance: "low-medium",
@@ -67,7 +126,21 @@ export const bankConfigs = {
     negotiationStyle: "methodical",
     specializations: ["real estate", "construction"],
     decisionSpeed: "medium",
-    flexibility: "medium"
+    flexibility: "medium",
+    esgFocusAreas: [
+      "green buildings",
+      "climate resilience infrastructure"
+    ],
+    esgExclusionList: [
+      "single-use plastics manufacturing",
+      "land speculation without community benefit"
+    ],
+    esgMinimumScore: 74,
+    esgIncentives: "0.30% margin reduction for LEED Gold or WELL certified projects with resilience KPIs",
+    esgReportingExpectations: "Biannual ESG reporting aligned to GRESB benchmarks and climate scenario analysis",
+    esgScoringWeights: { environmental: 0.5, social: 0.25, governance: 0.25 },
+    impactPreference: "Prioritizes projects delivering community resilience and sustainable materials sourcing",
+    transitionFinancePolicy: "Mandates climate risk assessments aligned to NGFS scenarios and board-level oversight"
   },
   "Zeta Commercial": {
     riskTolerance: "high",
@@ -81,6 +154,20 @@ export const bankConfigs = {
     negotiationStyle: "competitive",
     specializations: ["technology", "renewable energy", "innovation"],
     decisionSpeed: "very fast",
-    flexibility: "very high"
+    flexibility: "very high",
+    esgFocusAreas: [
+      "innovation-driven climate solutions",
+      "advanced recycling"
+    ],
+    esgExclusionList: [
+      "fossil fuel exploration",
+      "human rights controversies"
+    ],
+    esgMinimumScore: 66,
+    esgIncentives: "0.40% rate reduction plus milestone-based grant tranches for breakthrough emissions technology",
+    esgReportingExpectations: "Monthly KPI updates with API access to a shared sustainability data warehouse",
+    esgScoringWeights: { environmental: 0.55, social: 0.25, governance: 0.2 },
+    impactPreference: "Seeks outsized decarbonisation outcomes with scalable market potential",
+    transitionFinancePolicy: "Backs transition plans tied to science-based trajectories with equity upside sharing"
   }
 }

--- a/src/data/companyConfigs.js
+++ b/src/data/companyConfigs.js
@@ -1,74 +1,119 @@
 // Company configurations for negotiation preferences
 export const companyConfigs = {
-  "TechStart Solutions": {
-    urgency: "high",
-    acceptableInterestRate: "up to 8%",
-    collateralAvailability: "limited equipment",
-    creditScore: 720,
-    cashFlow: "positive but variable",
-    businessStage: "growth",
-    negotiationStyle: "flexible",
-    priorityFactors: ["speed", "low collateral requirements"],
-    maxAcceptableRate: 8.5,
-    preferredDuration: "12-24 months",
-    industry: "technology",
-    riskProfile: "medium"
-  },
-  "Green Energy Corp": {
-    urgency: "medium",
-    acceptableInterestRate: "up to 6%",
-    collateralAvailability: "substantial assets and equipment",
-    creditScore: 780,
-    cashFlow: "strong and stable",
-    businessStage: "expansion",
-    negotiationStyle: "thorough",
-    priorityFactors: ["low interest rate", "long term"],
-    maxAcceptableRate: 7.0,
-    preferredDuration: "36-60 months",
-    industry: "renewable energy",
-    riskProfile: "low-medium"
-  },
-  "HealthTech Innovations": {
+  "Aurora Renewables": {
     urgency: "medium-high",
+    acceptableInterestRate: "up to 6.2%",
+    collateralAvailability: "portfolio of PPA contracts and turbine assets",
+    creditScore: 785,
+    cashFlow: "long-term PPAs with tier-1 utilities",
+    businessStage: "scale-up",
+    negotiationStyle: "impact-focused",
+    priorityFactors: [
+      "certainty of funding",
+      "pricing incentives for science-based targets"
+    ],
+    maxAcceptableRate: 6.5,
+    preferredDuration: "36-84 months",
+    industry: "renewable energy",
+    riskProfile: "low-medium",
+    esgScore: 86,
+    esgCertifications: ["Science Based Targets initiative", "ISO 14001"],
+    impactMetrics: ["annual avoided emissions", "community energy access reinvestment"],
+    sustainabilityGoals: "Net-zero operations by 2030 with 15% community energy access allocation",
+    esgReportingFrameworks: ["TCFD", "GRI"],
+    esgConstraints: ["no partnerships with coal-dependent suppliers"]
+  },
+  "BlueRiver Logistics": {
+    urgency: "medium",
     acceptableInterestRate: "up to 7%",
-    collateralAvailability: "intellectual property and equipment",
+    collateralAvailability: "fleet assets and logistics hubs",
+    creditScore: 710,
+    cashFlow: "stable contracted revenues with major retailers",
+    businessStage: "established",
+    negotiationStyle: "data-driven",
+    priorityFactors: [
+      "green fleet financing",
+      "flexible amortisation aligned to peak seasons"
+    ],
+    maxAcceptableRate: 7.2,
+    preferredDuration: "24-48 months",
+    industry: "logistics",
+    riskProfile: "medium",
+    esgScore: 72,
+    esgCertifications: ["SmartWay Transport Partner"],
+    impactMetrics: ["scope 1 emissions intensity", "driver safety performance"],
+    sustainabilityGoals: "50% electric fleet conversion by 2028 and 30% reduction in empty miles",
+    esgReportingFrameworks: ["SASB Transportation", "CDP"],
+    esgConstraints: ["avoid lenders without fleet decarbonisation incentives"]
+  },
+  "CivicWell Housing": {
+    urgency: "high",
+    acceptableInterestRate: "up to 6.8%",
+    collateralAvailability: "municipal guarantees and property portfolio",
+    creditScore: 735,
+    cashFlow: "stable rent rolls with municipal subsidies",
+    businessStage: "mission-driven nonprofit",
+    negotiationStyle: "collaborative",
+    priorityFactors: [
+      "community affordability covenants",
+      "extended tenor"
+    ],
+    maxAcceptableRate: 7.0,
+    preferredDuration: "60-120 months",
+    industry: "real estate development",
+    riskProfile: "low-medium",
+    esgScore: 78,
+    esgCertifications: ["Enterprise Green Communities"],
+    impactMetrics: ["affordable units created", "resident well-being index"],
+    sustainabilityGoals: "Deliver 500 net-zero affordable homes with resilience retrofits by 2032",
+    esgReportingFrameworks: ["GRESB", "IRIS+"],
+    esgConstraints: ["requires lenders supporting social impact reporting"]
+  },
+  "MediBridge Health": {
+    urgency: "medium-high",
+    acceptableInterestRate: "up to 7.4%",
+    collateralAvailability: "medical equipment and IP portfolio",
     creditScore: 690,
-    cashFlow: "growing but uneven",
-    businessStage: "development",
-    negotiationStyle: "cautious",
-    priorityFactors: ["flexible terms", "understanding of industry"],
-    maxAcceptableRate: 7.5,
+    cashFlow: "growing subscription revenue from hospital networks",
+    businessStage: "growth",
+    negotiationStyle: "evidence-led",
+    priorityFactors: [
+      "clinical outcome incentives",
+      "structured drawdowns"
+    ],
+    maxAcceptableRate: 7.8,
     preferredDuration: "18-36 months",
     industry: "healthcare technology",
-    riskProfile: "medium-high"
+    riskProfile: "medium-high",
+    esgScore: 69,
+    esgCertifications: ["HIPAA compliance attestation"],
+    impactMetrics: ["patient access hours enabled", "reduced readmission rates"],
+    sustainabilityGoals: "Expand telehealth access for 200 rural clinics while maintaining data governance best practices",
+    esgReportingFrameworks: ["SASB Health Care Delivery", "HITECH"],
+    esgConstraints: ["partners must support data privacy oversight and responsible AI policy"]
   },
-  "Manufacturing Plus": {
+  "Harbor Manufacturing Group": {
     urgency: "low",
-    acceptableInterestRate: "up to 6.5%",
-    collateralAvailability: "extensive machinery and property",
-    creditScore: 750,
-    cashFlow: "stable and predictable",
+    acceptableInterestRate: "up to 6.4%",
+    collateralAvailability: "advanced machinery and owned facilities",
+    creditScore: 760,
+    cashFlow: "predictable OEM contracts with backlog visibility",
     businessStage: "established",
     negotiationStyle: "methodical",
-    priorityFactors: ["competitive rates", "established relationship"],
-    maxAcceptableRate: 7.0,
-    preferredDuration: "24-48 months",
-    industry: "manufacturing",
-    riskProfile: "low"
-  },
-  "Retail Dynamics": {
-    urgency: "high",
-    acceptableInterestRate: "up to 9%",
-    collateralAvailability: "inventory and store assets",
-    creditScore: 680,
-    cashFlow: "seasonal variations",
-    businessStage: "mature",
-    negotiationStyle: "results-oriented",
-    priorityFactors: ["quick approval", "seasonal flexibility"],
-    maxAcceptableRate: 9.5,
-    preferredDuration: "12-30 months",
-    industry: "retail",
-    riskProfile: "medium"
+    priorityFactors: [
+      "capex for electrification",
+      "supply-chain resilience"
+    ],
+    maxAcceptableRate: 6.8,
+    preferredDuration: "36-72 months",
+    industry: "advanced manufacturing",
+    riskProfile: "low-medium",
+    esgScore: 80,
+    esgCertifications: ["ISO 50001", "Responsible Business Alliance"],
+    impactMetrics: ["energy intensity per unit produced", "supplier ESG compliance rate"],
+    sustainabilityGoals: "Achieve 60% renewable-powered operations by 2029 and zero waste-to-landfill by 2030",
+    esgReportingFrameworks: ["SASB Industrial Machinery", "CDP"],
+    esgConstraints: ["must maintain supplier code-of-conduct enforcement"]
   }
 }
 
@@ -95,15 +140,21 @@ export const generateCompanyConfig = (companyName, intent) => {
   let urgency = "medium"
   let maxRate = 7.5
   let riskProfile = "medium"
-  
+  let esgScore = 72
+  let sustainabilityGoals = "Implement credible emissions reductions within project scope"
+
   if (amount > 1000000) {
     urgency = "low"
     maxRate = 7.0
     riskProfile = "low-medium"
+    esgScore = 78
+    sustainabilityGoals = "Deliver multi-year efficiency improvements while meeting climate disclosure expectations"
   } else if (amount < 250000) {
     urgency = "high"
     maxRate = 9.0
     riskProfile = "medium-high"
+    esgScore = 65
+    sustainabilityGoals = "Secure quick capital while maintaining minimum ESG compliance"
   }
 
   return {
@@ -118,6 +169,12 @@ export const generateCompanyConfig = (companyName, intent) => {
     maxAcceptableRate: maxRate,
     preferredDuration: `${intent.duration}-${intent.duration + 12} months`,
     industry,
-    riskProfile
+    riskProfile,
+    esgScore,
+    esgCertifications: ["ISO 14001 (in progress)"],
+    impactMetrics: ["baseline emissions reduction", "employee well-being"],
+    sustainabilityGoals,
+    esgReportingFrameworks: ["TCFD"],
+    esgConstraints: ["must avoid high-controversy suppliers"]
   }
 }

--- a/src/data/sampleData.js
+++ b/src/data/sampleData.js
@@ -2,28 +2,28 @@ export const sampleData = {
   intents: [
     {
       id: 1001,
-      companyName: "TechStart Solutions",
-      amount: 500000,
-      duration: 12,
-      purpose: "Equipment purchase and expansion",
+      companyName: "Aurora Renewables",
+      amount: 3500000,
+      duration: 48,
+      purpose: "Expand hybrid solar and battery storage assets for community energy contracts",
       status: "open",
       timestamp: "2025-09-20T01:30:00Z"
     },
     {
       id: 1002,
-      companyName: "Green Energy Corp",
-      amount: 2000000,
-      duration: 24,
-      purpose: "Solar panel manufacturing facility",
+      companyName: "BlueRiver Logistics",
+      amount: 1250000,
+      duration: 36,
+      purpose: "Electrify regional distribution fleet and install smart-charging depots",
       status: "open",
       timestamp: "2025-09-20T01:15:00Z"
     },
     {
       id: 1003,
-      companyName: "HealthTech Innovations",
-      amount: 750000,
-      duration: 18,
-      purpose: "Medical device development",
+      companyName: "MediBridge Health",
+      amount: 800000,
+      duration: 24,
+      purpose: "Launch telehealth platform for rural clinics with responsible AI triage safeguards",
       status: "open",
       timestamp: "2025-09-20T02:00:00Z"
     }
@@ -32,49 +32,49 @@ export const sampleData = {
     {
       id: "deal-1",
       intentId: 1001,
-      companyName: "TechStart Solutions",
+      companyName: "Aurora Renewables",
       bankName: "Alpha Bank",
       timestamp: "2025-09-20T01:35:00Z"
     },
     {
       id: "deal-2",
-      intentId: 1002,
-      companyName: "Green Energy Corp",
-      bankName: "Beta Financial",
-      timestamp: "2025-09-20T01:25:00Z"
+      intentId: 1001,
+      companyName: "Aurora Renewables",
+      bankName: "Zeta Commercial",
+      timestamp: "2025-09-20T01:36:30Z"
     },
     {
       id: "deal-3",
       intentId: 1002,
-      companyName: "Green Energy Corp",
-      bankName: "Gamma Capital",
+      companyName: "BlueRiver Logistics",
+      bankName: "Delta Bank",
       timestamp: "2025-09-20T01:28:00Z"
     },
     {
       id: "deal-4",
       intentId: 1003,
-      companyName: "HealthTech Innovations",
-      bankName: "Delta Bank",
+      companyName: "MediBridge Health",
+      bankName: "Gamma Capital",
       timestamp: "2025-09-20T02:05:00Z"
     }
   ],
   closedDeals: [
     {
       id: 1000,
-      companyName: "Manufacturing Plus",
+      companyName: "Harbor Manufacturing Group",
       winningBank: "Delta Bank",
-      amount: 750000,
-      duration: 18,
-      purpose: "Equipment upgrade and facility expansion",
+      amount: 2200000,
+      duration: 48,
+      purpose: "Factory electrification, robotics upgrade, and supplier ESG integration",
       timestamp: "2025-09-19T15:45:00Z"
     },
     {
       id: 999,
-      companyName: "Retail Dynamics",
-      winningBank: "Alpha Bank",
-      amount: 300000,
-      duration: 12,
-      purpose: "Working capital and inventory management",
+      companyName: "CivicWell Housing",
+      winningBank: "Epsilon Trust",
+      amount: 1500000,
+      duration: 72,
+      purpose: "Net-zero affordable housing retrofit programme with resilience upgrades",
       timestamp: "2025-09-19T10:30:00Z"
     }
   ]
@@ -82,11 +82,39 @@ export const sampleData = {
 
 export const availableBanks = [
   "Alpha Bank",
-  "Beta Financial", 
+  "Beta Financial",
   "Gamma Capital",
   "Delta Bank",
   "Epsilon Trust",
   "Zeta Commercial"
+]
+
+export const availableCompanies = [
+  {
+    id: "aurora-renewables",
+    name: "Aurora Renewables",
+    description: "Utility-scale clean energy developer with community benefit agreements"
+  },
+  {
+    id: "blueriver-logistics",
+    name: "BlueRiver Logistics",
+    description: "National logistics operator decarbonising fleet operations"
+  },
+  {
+    id: "civicwell-housing",
+    name: "CivicWell Housing",
+    description: "Mission-driven housing developer delivering resilient net-zero communities"
+  },
+  {
+    id: "medibridge-health",
+    name: "MediBridge Health",
+    description: "Healthcare technology company expanding telehealth access with robust governance"
+  },
+  {
+    id: "harbor-manufacturing-group",
+    name: "Harbor Manufacturing Group",
+    description: "Advanced manufacturer electrifying operations and enforcing responsible supply chains"
+  }
 ]
 
 export const roles = [

--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -1,38 +1,98 @@
 import axios from 'axios'
 
+const formatList = (items, fallback = 'None specified') => {
+  if (Array.isArray(items) && items.length > 0) {
+    return items.join(', ')
+  }
+  return fallback
+}
+
+const formatNumber = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value.toLocaleString()
+  }
+  return value ?? 'Not specified'
+}
+
+const formatESGWeights = (weights) => {
+  if (!weights || typeof weights !== 'object') {
+    return 'Environmental 40%, Social 30%, Governance 30%'
+  }
+
+  return Object.entries(weights)
+    .map(([key, value]) => {
+      let display = value
+      if (typeof value === 'number') {
+        display = value <= 1 ? `${Math.round(value * 100)}%` : `${Math.round(value)}%`
+      }
+      const label = key.charAt(0).toUpperCase() + key.slice(1)
+      return `${label} ${display}`
+    })
+    .join(', ')
+}
+
+const safeText = (value, fallback = 'Not specified') => {
+  if (value === null || value === undefined) {
+    return fallback
+  }
+  return String(value)
+}
+
 // Mock identity verification function
 export const verifyIdentity = async (companyName, intent) => {
-  // Simulate API delay
   await new Promise(resolve => setTimeout(resolve, 1000))
-  
-  // Return random boolean for now (80% success rate)
   return Math.random() > 0.2
-  // return true
 }
 
 // Generate initial bank offer using LLM
-export const generateOfferLLM = async (intent, bankConfig, bankName) => {
+export const generateOfferLLM = async (intent, bankConfig = {}, bankName) => {
   try {
-    const systemPrompt = `You are an AI representing ${bankName}, a financial institution. Based on the bank's configuration and the company's credit request, generate a professional loan offer. Be specific about terms including interest rate, duration, collateral requirements, and any conditions.
+    const systemPrompt = `You are the structured credit AI officer for ${bankName}. Use the bank's credit guardrails and ESG commitments to craft a loan proposal that fits the company's request.
 
-Bank Configuration:
-- Risk Tolerance: ${bankConfig.riskTolerance}
-- Preferred Interest Rate Range: ${bankConfig.preferredInterestRate}
-- Max Loan Amount: $${bankConfig.maxLoanAmount.toLocaleString()}
-- Min Loan Amount: $${bankConfig.minLoanAmount.toLocaleString()}
-- Preferred Duration: ${bankConfig.preferredDuration}
-- Collateral Requirements: ${bankConfig.requiredCollateral}
-- Credit Score Requirement: ${bankConfig.creditScoreRequirement}
-- Processing Fee: ${bankConfig.processingFee}
-- Negotiation Style: ${bankConfig.negotiationStyle}
-- Specializations: ${bankConfig.specializations.join(', ')}
+Bank Credit & ESG Parameters:
+- Risk Appetite: ${safeText(bankConfig.riskTolerance)}
+- Preferred Interest Rate Range: ${safeText(bankConfig.preferredInterestRate)}
+- Ticket Size: $${formatNumber(bankConfig.minLoanAmount)} - $${formatNumber(bankConfig.maxLoanAmount)}
+- Preferred Tenor: ${safeText(bankConfig.preferredDuration)}
+- Collateral Position: ${safeText(bankConfig.requiredCollateral)}
+- Credit Score Requirement: ${safeText(bankConfig.creditScoreRequirement)}
+- Processing Fee: ${safeText(bankConfig.processingFee)}
+- Negotiation Style: ${safeText(bankConfig.negotiationStyle)}
+- Specialisations: ${formatList(bankConfig.specializations)}
+- Decision Speed: ${safeText(bankConfig.decisionSpeed)}
+- Flexibility: ${safeText(bankConfig.flexibility)}
+- ESG Focus Areas: ${formatList(bankConfig.esgFocusAreas)}
+- ESG Exclusion List: ${formatList(bankConfig.esgExclusionList)}
+- Minimum ESG Score: ${safeText(bankConfig.esgMinimumScore)}
+- ESG Incentives: ${safeText(bankConfig.esgIncentives)}
+- ESG Reporting Expectations: ${safeText(bankConfig.esgReportingExpectations)}
+- ESG Scoring Weights: ${formatESGWeights(bankConfig.esgScoringWeights)}
+- Impact Preference: ${safeText(bankConfig.impactPreference)}
+- Transition Finance Policy: ${safeText(bankConfig.transitionFinancePolicy)}
 
-Generate a professional, concise loan offer (2-3 sentences) that reflects the bank's style and requirements.`
+Respond in the following format:
+Offer Summary:
+- Key highlights
+Credit Terms:
+- Loan Amount:
+- Interest Rate:
+- Tenor:
+- Collateral:
+ESG Alignment:
+- How the offer aligns with the bank's ESG requirements
+Conditions & Monitoring:
+- Key covenants or reporting expectations
+Next Steps:
+- Closing actions or timeline guidance
+Keep the tone professional and aligned with the bank's negotiation style.`
 
-    const userContent = `Company: ${intent.companyName}
-Requested Amount: $${intent.amount.toLocaleString()}
-Duration: ${intent.duration} months
-Purpose: ${intent.purpose}`
+    const userContent = `Company Credit Request:
+- Company: ${intent.companyName}
+- Requested Amount: $${formatNumber(intent.amount)}
+- Requested Tenor: ${intent.duration} months
+- Purpose: ${intent.purpose}
+
+Produce a concise offer using the requested format.`
 
     const response = await axios.post(
       'https://openrouter.ai/api/v1/chat/completions',
@@ -40,14 +100,14 @@ Purpose: ${intent.purpose}`
         model: 'openai/gpt-oss-20b:free',
         messages: [
           { role: 'system', content: systemPrompt },
-          { role: 'user', content: userContent },
-        ],
+          { role: 'user', content: userContent }
+        ]
       },
       {
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`,
-        },
+          Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`
+        }
       }
     )
 
@@ -59,26 +119,38 @@ Purpose: ${intent.purpose}`
 }
 
 // Generate bank counter-offer using chat history
-export const generateCounterOfferLLM = async (conversation, bankConfig, bankName, intent) => {
+export const generateCounterOfferLLM = async (conversation, bankConfig = {}, bankName, intent) => {
   try {
-    const chatHistory = conversation.map(msg => 
-      `${msg.sender}: ${msg.content}`
-    ).join('\n')
+    const chatHistory = conversation.map(msg => `${msg.sender}: ${msg.content}`).join('\n')
 
-    const systemPrompt = `You are an AI representing ${bankName}. Based on the ongoing negotiation and your bank's configuration, generate a counter-offer response. Consider the company's previous response and adjust terms accordingly while staying within your bank's parameters.
+    const systemPrompt = `You are the negotiation lead for ${bankName}. Craft a counter-offer that respects the bank's credit policy and ESG parameters while progressing the deal.
 
-Bank Configuration:
-- Risk Tolerance: ${bankConfig.riskTolerance}
-- Preferred Interest Rate Range: ${bankConfig.preferredInterestRate}
-- Negotiation Style: ${bankConfig.negotiationStyle}
-- Flexibility: ${bankConfig.flexibility}
+Bank Profile Snapshot:
+- Risk Appetite: ${safeText(bankConfig.riskTolerance)}
+- Interest Rate Range: ${safeText(bankConfig.preferredInterestRate)}
+- Flexibility: ${safeText(bankConfig.flexibility)}
+- Negotiation Style: ${safeText(bankConfig.negotiationStyle)}
+- ESG Focus Areas: ${formatList(bankConfig.esgFocusAreas)}
+- ESG Incentives: ${safeText(bankConfig.esgIncentives)}
+- Minimum ESG Score: ${safeText(bankConfig.esgMinimumScore)}
+- Transition Finance Policy: ${safeText(bankConfig.transitionFinancePolicy)}
 
-Generate a professional counter-offer (2-3 sentences) that shows willingness to negotiate while protecting the bank's interests.`
+Respond in this structure:
+Response Summary:
+- Revised Rate:
+- Tenor:
+- Collateral:
+ESG Alignment Update:
+- How the counter maintains ESG guardrails
+Conditions & Monitoring:
+- Any additional requirements or reporting cadence
+Negotiation Message:
+- 2 short paragraphs addressed to ${intent.companyName} summarising rationale.`
 
-    const userContent = `Previous conversation:
-${chatHistory}
+    const userContent = `Negotiation conversation so far:
+${chatHistory || 'No prior messages'}
 
-Generate your counter-offer response.`
+Provide the counter-offer using the specified structure.`
 
     const response = await axios.post(
       'https://openrouter.ai/api/v1/chat/completions',
@@ -86,14 +158,14 @@ Generate your counter-offer response.`
         model: 'openai/gpt-oss-20b:free',
         messages: [
           { role: 'system', content: systemPrompt },
-          { role: 'user', content: userContent },
-        ],
+          { role: 'user', content: userContent }
+        ]
       },
       {
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`,
-        },
+          Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`
+        }
       }
     )
 
@@ -105,37 +177,60 @@ Generate your counter-offer response.`
 }
 
 // Evaluate offer and generate company response
-export const evaluateOfferLLM = async (intent, bankOffer, companyConfig, conversation = []) => {
+export const evaluateOfferLLM = async (intent, bankOffer, companyConfig = {}, bankConfig = {}, bankName, conversation = []) => {
   try {
-    const chatHistory = conversation.length > 0 ? 
-      conversation.map(msg => `${msg.sender}: ${msg.content}`).join('\n') : 
-      'This is the first offer from the bank.'
+    const chatHistory = conversation.length > 0
+      ? conversation.map(msg => `${msg.sender}: ${msg.content}`).join('\n')
+      : 'This is the first offer from the bank.'
 
-    const systemPrompt = `You are an AI representing ${intent.companyName}. Based on your company's configuration and the bank's offer, decide whether to accept the offer or provide a counter-offer. Be realistic about what terms are acceptable.
+    const systemPrompt = `You are the sustainability-focused credit lead for ${intent.companyName}. Assess ${bankName}'s latest offer against the company's credit preferences and ESG commitments, then craft an appropriate response.
 
-Company Configuration:
-- Urgency: ${companyConfig.urgency}
-- Acceptable Interest Rate: ${companyConfig.acceptableInterestRate}
-- Max Acceptable Rate: ${companyConfig.maxAcceptableRate}%
-- Preferred Duration: ${companyConfig.preferredDuration}
-- Collateral Availability: ${companyConfig.collateralAvailability}
-- Credit Score: ${companyConfig.creditScore}
-- Negotiation Style: ${companyConfig.negotiationStyle}
-- Priority Factors: ${companyConfig.priorityFactors.join(', ')}
+Company Credit & ESG Profile:
+- Urgency: ${safeText(companyConfig.urgency)}
+- Acceptable Interest Rate: ${safeText(companyConfig.acceptableInterestRate)}
+- Max Acceptable Rate: ${safeText(companyConfig.maxAcceptableRate)}%
+- Preferred Duration: ${safeText(companyConfig.preferredDuration)}
+- Collateral Availability: ${safeText(companyConfig.collateralAvailability)}
+- Credit Score: ${safeText(companyConfig.creditScore)}
+- Negotiation Style: ${safeText(companyConfig.negotiationStyle)}
+- Priority Factors: ${formatList(companyConfig.priorityFactors)}
+- ESG Score: ${safeText(companyConfig.esgScore)}
+- ESG Certifications: ${formatList(companyConfig.esgCertifications)}
+- Impact Metrics: ${formatList(companyConfig.impactMetrics)}
+- Sustainability Goals: ${safeText(companyConfig.sustainabilityGoals)}
+- ESG Reporting Frameworks: ${formatList(companyConfig.esgReportingFrameworks)}
+- ESG Constraints: ${formatList(companyConfig.esgConstraints)}
 
-If the offer is acceptable, respond with acceptance. If not, provide a professional counter-offer (2-3 sentences) that addresses your concerns while being reasonable.`
+Bank Offer Context:
+- Bank Negotiation Style: ${safeText(bankConfig.negotiationStyle)}
+- ESG Focus Areas: ${formatList(bankConfig.esgFocusAreas)}
+- Minimum ESG Score: ${safeText(bankConfig.esgMinimumScore)}
+- ESG Incentives: ${safeText(bankConfig.esgIncentives)}
+- Reporting Expectations: ${safeText(bankConfig.esgReportingExpectations)}
+- Impact Preference: ${safeText(bankConfig.impactPreference)}
+- Transition Policy: ${safeText(bankConfig.transitionFinancePolicy)}
+
+Respond with a message that begins with "Decision: ACCEPT", "Decision: COUNTER", or "Decision: DECLINE". After the decision line, include:
+ESG Assessment:
+- Bullet list on ESG alignment or gaps
+Key Considerations:
+- Credit or structuring factors influencing the decision
+Negotiation Message:
+- 2 short paragraphs addressed to ${bankName} summarising the rationale and, if countering, the revised terms (interest rate, tenor, collateral expectations).
+Keep the overall response concise.`
 
     const userContent = `Original Request:
-Amount: $${intent.amount.toLocaleString()}
-Duration: ${intent.duration} months
-Purpose: ${intent.purpose}
+- Amount: $${formatNumber(intent.amount)}
+- Duration: ${intent.duration} months
+- Purpose: ${intent.purpose}
 
 Conversation so far:
 ${chatHistory}
 
-Current Bank Offer: ${bankOffer}
+Current Bank Offer:
+${bankOffer}
 
-Respond with either acceptance or a counter-offer.`
+Produce the decision-oriented response now.`
 
     const response = await axios.post(
       'https://openrouter.ai/api/v1/chat/completions',
@@ -143,30 +238,124 @@ Respond with either acceptance or a counter-offer.`
         model: 'openai/gpt-oss-20b:free',
         messages: [
           { role: 'system', content: systemPrompt },
-          { role: 'user', content: userContent },
-        ],
+          { role: 'user', content: userContent }
+        ]
       },
       {
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`,
-        },
+          Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`
+        }
       }
     )
 
-    const responseContent = response.data.choices[0].message.content
-    
-    // Determine if this is an acceptance or counter-offer
-    const isAcceptance = responseContent.toLowerCase().includes('accept') || 
-                        responseContent.toLowerCase().includes('agree') ||
-                        responseContent.toLowerCase().includes('deal')
-    
+    const responseContent = response.data.choices[0].message.content?.trim() || ''
+
+    const decisionMatch = responseContent.match(/Decision\s*:\s*([^\n]+)/i)
+    const rawDecision = decisionMatch ? decisionMatch[1].trim() : null
+    const normalizedDecision = rawDecision ? rawDecision.toUpperCase() : null
+    const isAcceptance = normalizedDecision
+      ? normalizedDecision.includes('ACCEPT') || normalizedDecision.includes('APPROVE')
+      : false
+
     return {
       content: responseContent,
-      isAcceptance
+      isAcceptance,
+      decision: normalizedDecision
     }
   } catch (error) {
     console.error('OpenRouter API error:', error)
     throw new Error('Failed to evaluate offer. Please try again.')
+  }
+}
+
+// Evaluate multiple offers collectively for a single intent
+export const evaluateAllOffersLLM = async (intent, offers = [], companyConfig = {}) => {
+  try {
+    const offersOverview = offers.map((offer, index) => {
+      const bankConfig = offer.bankConfig || {}
+      return `Offer ${index + 1} - ${offer.bankName}:
+Status: ${safeText(offer.negotiationStatus, 'unknown')}
+Latest Offer Summary: ${offer.latestOffer || 'No formalised offer.'}
+Bank ESG Focus: ${formatList(bankConfig.esgFocusAreas)}
+ESG Exclusion List: ${formatList(bankConfig.esgExclusionList)}
+Minimum ESG Score: ${safeText(bankConfig.esgMinimumScore)}
+ESG Incentives: ${safeText(bankConfig.esgIncentives)}
+Reporting Expectations: ${safeText(bankConfig.esgReportingExpectations)}
+Impact Preference: ${safeText(bankConfig.impactPreference)}
+Conversation Highlights:
+${offer.conversationExcerpt || 'No conversation history captured yet.'}`
+    }).join('\n\n---\n\n')
+
+    const systemPrompt = `You are the sustainability credit strategist advising ${intent.companyName}. Review all bank proposals at once and recommend the path that best balances credit fit with ESG commitments.
+
+Company Credit & ESG Profile:
+- Urgency: ${safeText(companyConfig.urgency)}
+- Acceptable Interest Rate: ${safeText(companyConfig.acceptableInterestRate)}
+- Max Acceptable Rate: ${safeText(companyConfig.maxAcceptableRate)}%
+- Preferred Duration: ${safeText(companyConfig.preferredDuration)}
+- Collateral Availability: ${safeText(companyConfig.collateralAvailability)}
+- Credit Score: ${safeText(companyConfig.creditScore)}
+- Negotiation Style: ${safeText(companyConfig.negotiationStyle)}
+- Priority Factors: ${formatList(companyConfig.priorityFactors)}
+- ESG Score: ${safeText(companyConfig.esgScore)}
+- ESG Certifications: ${formatList(companyConfig.esgCertifications)}
+- Impact Metrics: ${formatList(companyConfig.impactMetrics)}
+- Sustainability Goals: ${safeText(companyConfig.sustainabilityGoals)}
+- ESG Reporting Frameworks: ${formatList(companyConfig.esgReportingFrameworks)}
+- ESG Constraints: ${formatList(companyConfig.esgConstraints)}
+
+Respond with:
+Decision: SELECT <Bank Name> | REQUEST_REVISIONS | DECLINE_ALL
+Recommended Partner: <Bank Name or NONE>
+Rationale:
+- Bullet list explaining the recommendation
+Offer Ranking:
+1. ...
+2. ...
+ESG Alignment Summary:
+- Bullet list referencing how each offer meets or misses ESG requirements
+Next Steps:
+- Actionable items for the company team`
+
+    const userContent = `Intent Details:
+- Requested Amount: $${formatNumber(intent.amount)}
+- Duration: ${intent.duration} months
+- Purpose: ${intent.purpose}
+
+Offers Under Review:
+${offersOverview || 'No offers have been submitted yet.'}
+
+Deliver the decision using the required format.`
+
+    const response = await axios.post(
+      'https://openrouter.ai/api/v1/chat/completions',
+      {
+        model: 'openai/gpt-oss-20b:free',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userContent }
+        ]
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`
+        }
+      }
+    )
+
+    const responseContent = response.data.choices[0].message.content?.trim() || ''
+    const decisionMatch = responseContent.match(/Decision\s*:\s*([^\n]+)/i)
+    const recommendedMatch = responseContent.match(/Recommended Partner\s*:\s*([^\n]+)/i)
+
+    return {
+      content: responseContent,
+      decision: decisionMatch ? decisionMatch[1].trim().toUpperCase() : null,
+      recommendedPartner: recommendedMatch ? recommendedMatch[1].trim() : null
+    }
+  } catch (error) {
+    console.error('OpenRouter API error:', error)
+    throw new Error('Failed to evaluate offers collectively. Please try again.')
   }
 }


### PR DESCRIPTION
## Summary
- expand bank and company configurations with detailed ESG policy fields and refresh sample intents, deals, and selectable entities
- add company selector support in the header and intent form plus ESG evaluation controls and results in open intent cards
- overhaul LLM prompts to incorporate ESG requirements, add collective offer decisioning, and update negotiation evaluation logic accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d002cfb8f48322a6308d267592a5f5